### PR TITLE
Update bootstrap-switch.less

### DIFF
--- a/resources/less/bootstrap-switch.less
+++ b/resources/less/bootstrap-switch.less
@@ -80,6 +80,11 @@
     }
 }
 
+// Override overflow for webkit browsers
+@media screen and (-webkit-min-device-pixel-ratio:0) {
+    .bootstrap-switch { overflow: visible !important; }
+}
+
 // `On` handler
 .bootstrap-switch-handle-on {
     border-bottom-left-radius: 30px;


### PR DESCRIPTION
Overflow none breaks webkit browsers.  The method being used for masking is not a standards based method.  As such overflow functions different on various browsers.  This fix was tested on IE9+, Chrome, Firefox successfully.
